### PR TITLE
Add robust checks around serial communication

### DIFF
--- a/module.py
+++ b/module.py
@@ -38,12 +38,20 @@ class Module:
     
     def show_inputs(self):
         response = self.connection.get_data()
+        if not response:
+            logger.error("Empty response from module")
+            return
+
         data, checksum = self.dcon.parsedResponse(response)
-        checksumVerificationStatus = self.dcon.checksum_verification(response)
+        if not self.dcon.checksum_verification(response):
+            logger.error("Checksum mismatch in response: %s", response)
+            return
+
         try:
             binary_data = ''.join(format(int(c, 16), '04b') for c in data)
-        except:
-            pass
+        except Exception as exc:
+            logger.error("Failed to parse response %s: %s", response, exc)
+            return
 
         activeInput     = f'color: "black"; background-color: red'
         inactiveInput   = f'color: "black"; background-color: gray'


### PR DESCRIPTION
## Summary
- validate port name before configuration
- handle serial port connection and write errors gracefully
- add connection/setup error handling in main window
- verify and parse module responses with checksum checks

## Testing
- `python -m py_compile main.py SerialConnection.py module.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab7f82e30c8329b0abc1513c10bd21